### PR TITLE
access files via 'filename' instead of 'name'

### DIFF
--- a/docs.md
+++ b/docs.md
@@ -15,7 +15,7 @@
 | `protocol` | always **https** | `Text` |
 | `port` | URL Port. Default to `443` if it's not defined | `Nat16` |
 | `host` | An object with the url host stored as a string and as an array. The array is the result of the string split at every dot.<br/> <br/> ```original = "www.google.com"```<br/> `array =  ["www", "google", "com"]` | `{original: Text; array: [Text]}` |
-| `path` | An object with the url paths stored as a string and as an array. The array is the result of the string split at every backslash. <br/>  <br/> `original = "/categories/items/32"`, <br/>```array = ["categories", "items", "32"] ```| `{original: Text; array: [Text]}` |
+| `path` | An object with the url paths stored as a string and as an array. The array is the result of the string split at every backslash. <br/>  <br/> `original = "/categories/items/32"`, <br/>```array = ["categories", "items", "32"] ``` <br/> <br/> A path with a trailing backslash will have an empty string at the end of `path.array` <br/>  <br/> `original = "/categories/items/"`, <br/>```array = ["categories", "items", ""] ```   | `{original: Text; array: [Text]}` |
 | `queryObj` | An object for accessing fields and values of a query string | [SearchParams](#searchParams) |
 | `anchor` | Everything after the symbol  `#` | `Text` |
 
@@ -52,8 +52,8 @@
 | `get` | Retrieves field values | `(Text) -> ?[Text]` |
 | `keys` | An array of all field keys | `[Text]` |
 | `trieMap` | Stores all field entries (data without a filename) | `TrieMap<Text, [Text]>` |
-| `fileKeys` | An array of all file keys | `[Text]` |
-| `files` | Retrieves files of a specific key/name | `(Text) -> ?[`[File](#file)`]` |
+| `fileKeys` | An array of all filenames | `[Text]` |
+| `files` | Retrieves files associated with a specific filename | `(Text) -> ?[`[File](#file)`]` |
 
 #### File
 | Property | Description | Type |

--- a/mops.toml
+++ b/mops.toml
@@ -1,6 +1,6 @@
 [package]
 name = "http-parser"
-version = "0.2.0"
+version = "0.3.0"
 description = "A http request parser for parsing url, search query, headers and form data."
 repository = "https://github.com/NatLabs/http-parser.mo"
 

--- a/src/lib.mo
+++ b/src/lib.mo
@@ -98,7 +98,7 @@ module HttpRequestParser {
         let raw_domain = (Option.get(headers.get("host"), [""]))[0];
 
         var domain = Option.get(Utils.decodeURIComponent(raw_domain), raw_domain);
-        let url = Option.get(Utils.decodeURIComponent(raw_url), raw_url);
+        var url = Option.get(Utils.decodeURIComponent(raw_url), raw_url);
 
         public let original = domain # url;
 
@@ -118,32 +118,30 @@ module HttpRequestParser {
             public let array = Iter.toArray(Text.tokens(_host, #char('.')));
         };
 
-        domain := url;
-
-        let p = Iter.toArray(Text.tokens(domain, #char('#')));
+        let p = Iter.toArray(Text.tokens(url, #char('#')));
 
         public let anchor = if (p.size() > 1) {
-            domain := p[0];
+            url := p[0];
             p[1];
         } else {
-            domain := p[0];
+            url := p[0];
             "";
         };
 
-        let re = Iter.toArray(Text.tokens(domain, #char('?')));
+        let re = Iter.toArray(Text.tokens(url, #char('?')));
 
         let queryString : Text = switch (re.size()) {
             case (0) {
-                domain := "";
+                url := "";
                 re[1];
             };
             case (1) {
-                domain := re[0];
+                url := re[0];
                 "";
             };
 
             case (_) {
-                domain := re[0];
+                url := re[0];
                 re[1];
             };
 
@@ -151,11 +149,12 @@ module HttpRequestParser {
 
         public let queryObj : SearchParams = SearchParams(queryString);
 
-        let path_iter = Text.tokens(domain, #char('/'));
-
         public let path = object {
+            public let original = url;
+
+            let path_iter = Text.split(url, #char('/'));
+            ignore path_iter.next();
             public let array = Iter.toArray(path_iter);
-            public let original = "/" # Text.join("/", Iter.fromArray(array));
         };
 
     };

--- a/tests/Parser.test.mo
+++ b/tests/Parser.test.mo
@@ -111,8 +111,8 @@ let success = run([
                                 host.original == "m7sm4-2iaaa-aaaab-qabra-cai.raw.ic0.app",
                                 host.array == ["m7sm4-2iaaa-aaaab-qabra-cai", "raw", "ic0", "app"],
 
-                                path.original == "/counter",
-                                path.array == ["counter"],
+                                path.original == "/counter/",
+                                path.array == ["counter", ""],
 
                                 queryObj.original == "tag=2526172523",
                                 queryObj.keys == ["tag"],
@@ -356,7 +356,7 @@ let success = run([
                                     case (null) true;
                                 },
 
-                                // body.bytes(9, 23).toArray() == ArrayModule.slice(bytes, 9, 23)
+                                body.bytes(9, 23).toArray() == ArrayModule.slice(bytes, 9, 23)
                             ]);
                         },
                     ),
@@ -385,30 +385,6 @@ let success = run([
                             let body = HttpParser.Body(blob, ?"multipart/form-data");
                             let { form } = body;
 
-                            Debug.print(debug_show ("original", body.original));
-                            Debug.print(debug_show ("size", body.size, blob.size()));
-                            Debug.print(debug_show ("text", body.text()));
-                            Debug.print(debug_show ("form.keys", form.keys));
-                            Debug.print(debug_show ("form.get(\"field1\")", form.get("field1")));
-                            Debug.print(debug_show ("form.fileKeys", form.fileKeys));
-                            Debug.print(
-                                debug_show (
-                                    "form.files(\"field2\")",
-                                    switch (form.files("field2")) {
-                                        case (?arr) ?(
-                                            arr[0].name,
-                                            arr[0].filename,
-                                            arr[0].mimeType,
-                                            arr[0].mimeSubType,
-                                            arr[0].start,
-                                            arr[0].end,
-                                            (arr[0].bytes.toArray(), Text.decodeUtf8(Blob.fromArray(arr[0].bytes.toArray()))),
-                                            (Utils.textToBytes("value2"), "value2"),
-                                        );
-                                        case (_) null;
-                                    },
-                                )
-                            );
                             assertAllTrue([
                                 body.original == blob,
                                 body.size == blob.size(),
@@ -417,30 +393,25 @@ let success = run([
                                 form.keys == ["field1"],
                                 form.get("field1") == ?["value1"],
 
-                                form.fileKeys == ["field2"],
+                                form.fileKeys == ["example.txt"],
 
-                                // switch (form.files("field2")) {
-                                //     case (?arr) {
-                                //         let file = arr[0];
+                                switch (form.files("example.txt")) {
+                                    case (?arr) {
+                                        let file = arr[0];
 
-                                //         assertAllTrue([
-                                //             file.name == "field2",
-                                //             file.filename == "example.txt",
-
-                                //             file.mimeType == "text",
-                                //             file.mimeSubType == "plain",
-
-                                //             file.start == 172,
-                                //             file.end == 178,
-
-                                //             file.bytes.toArray() == Utils.textToBytes("value2"),
-                                //             file.bytes.toArray() == ArrayModule.slice(blobArray, 172, 178)
-
-                                //         ]);
-                                //     };
-
-                                //     case (_) false;
-                                // },
+                                        assertAllTrue([
+                                            file.name == "field2",
+                                            file.filename == "example.txt",
+                                            file.mimeType == "text",
+                                            file.mimeSubType == "plain",
+                                            file.start == 172,
+                                            file.end == 178,
+                                            file.bytes.toArray() == Utils.textToBytes("value2"),
+                                            file.bytes.toArray() == ArrayModule.slice(blobArray, 172, 178)
+                                        ]);
+                                    };
+                                    case (_) false;
+                                },
                             ])
 
                         },

--- a/tests/form.test.mo
+++ b/tests/form.test.mo
@@ -1,0 +1,73 @@
+// @testmode wasi
+import Iter "mo:base/Iter";
+import Debug "mo:base/Debug";
+import Prelude "mo:base/Prelude";
+import Char "mo:base/Char";
+import Text "mo:base/Text";
+
+import Bench "mo:bench";
+
+import HttpParser "../src";
+
+let boundary = "----WebKitFormBoundary";
+
+var body_text = "";
+
+func add_file(filename : Text, content_type : Text, size : Nat) {
+    body_text #= "--" # boundary # "\r\n";
+    body_text #= "Content-Disposition: form-data; name=\"file\"; filename=\"" # filename # "\"\r\n";
+    body_text #= "Content-Type: " # content_type # "\r\n\r\n";
+
+    for (i in Iter.range(0, size - 1)) {
+        if (i % 100 == 99) {
+            body_text #= "\n";
+        } else {
+            body_text #= "a";
+        };
+    };
+
+    body_text #= "\r\n";
+};
+
+for (i in Iter.range(0, 1000)) {
+    add_file("file" # debug_show (i) # ".txt", "text/plain", i);
+};
+
+add_file("file.md", "text/markdown", (10 * 1024));
+add_file("file.c", "text/plain", (1024 ** 2) * 2);
+add_file("file.json", "application/json", (1024 ** 2) * 4);
+
+// end form
+body_text #= "--" # boundary # "--\r\n";
+let body = Text.encodeUtf8(body_text);
+
+let #ok(form) = HttpParser.parseForm(body, #multipart(null));
+
+for (i in Iter.range(0, 1000)){
+    let filename = "file" # debug_show (i) # ".txt";
+    let ?files = form.files(filename);
+
+    let file = files[0];
+    
+    assert (file.mimeType # "/" # file.mimeSubType == "text/plain");
+    assert (filename == file.filename);
+    assert file.bytes.size() == i;
+    assert file.end - file.start == i;
+};    
+
+let ?markdown = form.files("file.md");
+assert markdown[0].mimeType # "/" # markdown[0].mimeSubType == "text/markdown";
+assert markdown[0].filename == "file.md";
+assert markdown[0].bytes.size() == (10 * 1024);
+assert markdown[0].end - markdown[0].start == (10 * 1024);
+
+let ?c = form.files("file.c");
+assert c[0].mimeType # "/" # c[0].mimeSubType == "text/plain";
+assert c[0].filename == "file.c";
+assert c[0].bytes.size() == (1024 ** 2) * 2;
+
+let ?json = form.files("file.json");
+assert json[0].mimeType # "/" # json[0].mimeSubType == "application/json";
+assert json[0].filename == "file.json";
+assert json[0].bytes.size() == (1024 ** 2) * 4;
+


### PR DESCRIPTION
- [access files via 'filename' instead of 'name'](https://github.com/NatLabs/http-parser.mo/commit/d30650e7042418988ec33af369bbebc18bb7e2ec)
- add an empty string at the end of `url.path.array` if there is a trailing backslash
- 